### PR TITLE
feat: added wrapper around fetch with retry functionality

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import router from './router/index.js'
+import './utils/retryFetch.js'
 
 import App from './App.vue'
 

--- a/src/utils/retryFetch.js
+++ b/src/utils/retryFetch.js
@@ -1,0 +1,51 @@
+const {fetch: originalFetch} = window
+
+
+//
+const retryCriteria = (response) => {
+  //magic number, retry on serverside error. Client Side errors (3xx and 4xx) are ignored
+  return !response.ok && response.status >= 500
+}
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+
+/**
+ * Wrapper for @function window.fetch
+ * This function overwrites fetch to retry in case of a 5xx-based error-code. 
+ * It is intended to add stability to koordinattransformation, in case webproj, gsearch or another dependency of the site becomes unreliable
+ * Solution is based on: https://www.fabiofranchino.com/log/how-to-override-fetch-in-javascript-to-intercept-it/
+ * @param {Array} args  (same args as fetch: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
+ */
+window.fetch = async (...args) => {
+  let [resource, config] = args
+
+  const method = config?.method || 'GET'
+
+  if(method !== 'GET') {
+    console.warn('[retryFetch] POST detected: Koordinattransformation was not built with POST based workflows in mind. Watch out for possible bugs in state.')
+    return originalFetch(resource, config)
+  }
+
+  const maxAttempts = 3 
+  const delay = 100 //100 ms delay ensures that application doesn't spam calls
+
+  let attempt = 0
+  let response 
+  while(attempt < maxAttempts) {
+
+    try {
+      response = await originalFetch(resource, config)
+
+      if(response.ok || !retryCriteria(response) ){
+        return response
+      }
+
+    } catch (error) {
+      console.error(`[retryFetch] error: ${error}`)
+    }
+    attempt++
+    await wait(delay)
+  }
+  console.warn(`[retryFetch] warning: fetch failed ${maxAttempts} times. Application proceeds as if service is not available`)
+  return response
+}


### PR DESCRIPTION
# Beskrivelse

Et generelt ønske til vores webapps er, at UX skal gøres mere stabil. For at opnå dette, er fetch-funktionen blevet overskrevet med en custom fetch, som gentager et GET-request 3 gange med 100 ms mellemrum. 

## Oversigt over Ændringer

- [ ] Feature (retryFetch: i [retryFetch.js](https://github.com/SDFIdk/Koordinattransformation/blob/feat/fetchRetry/src/utils/retryFetch.js)

# Test
Brugertest samt testsuite er blevet udført

# Teknisk Beskrivelse

I [main.js](https://github.com/SDFIdk/Koordinattransformation/blob/feat/fetchRetry/src/main.js) importeres [retryFetch.js](https://github.com/SDFIdk/Koordinattransformation/tree/feat/fetchRetry/src/utils), som tilføjer en wrapper til window.fetch metoden.Ved GET-kald gentager wrapperen kaldet 3 gange i tilfælde af, at serveren returerer 5xx fejl. Ved POST + andre retur-koder gentages fetch ikke.



