### PR TITLE
Kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+node_modules
+dist
+playwright-report
+test-results
+tests
+.vscode
+.idea
+*.swp
+.DS_Store
+.env*
+charts

--- a/.github/actions/validate-chart/action.yml
+++ b/.github/actions/validate-chart/action.yml
@@ -1,0 +1,34 @@
+name: Validate Helm chart
+description: helm lint + template + kubeconform
+
+inputs:
+  helm-version:
+    description: helm version to install
+    default: v4.2.0
+  kubeconform-version:
+    description: kubeconform release tag
+    default: v0.7.0
+  kube-version:
+    description: kubernetes API version to validate rendered manifests against
+    default: "1.36.0"
+
+runs:
+  using: composite
+  steps:
+    - uses: azure/setup-helm@v5
+      with:
+        version: ${{ inputs.helm-version }}
+
+    - name: Install kubeconform
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/bin"
+        curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${{ inputs.kubeconform-version }}/kubeconform-linux-amd64.tar.gz" \
+          | tar -xz -C "$RUNNER_TEMP/bin" kubeconform
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+    - name: Validate chart
+      shell: bash
+      env:
+        KUBE_VERSION: ${{ inputs.kube-version }}
+      run: ./scripts/lint-chart.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci --no-audit --no-fund
+
+      - run: npm run lint
+
+      - run: npm run build

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,19 @@
+name: Chart
+
+on:
+  push:
+    branches: [main, k8s-prep]   # tags are validated inside release.yml
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/validate-chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.value }}
 
+      # gate the publish: chart.yml and release.yml run independently on a tag
+      # push, so this is the only thing that blocks a broken chart reaching ghcr
+      - uses: ./.github/actions/validate-chart
+
       - name: Assert package.json version matches tag
         run: |
           v=$(node -p "require('./package.json').version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.value }}
+
+      - name: Assert package.json version matches tag
+        run: |
+          v=$(node -p "require('./package.json').version")
+          if [ "$v" != "${{ steps.tag.outputs.value }}" ]; then
+            echo "::error::package.json version ($v) does not match tag (${{ steps.tag.outputs.value }})"
+            exit 1
+          fi
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/klimadatastyrelsen/koordinattransformation:${{ steps.tag.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Helm registry login
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push chart
+        run: |
+          TAG="${{ steps.tag.outputs.value }}"
+          helm package charts/koordinattransformation --version "$TAG" --app-version "$TAG" -d /tmp
+          helm push "/tmp/koordinattransformation-${TAG}.tgz" oci://ghcr.io/klimadatastyrelsen/charts

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,6 @@ public/
 dist/
 playwright-report/
 test-results/
-.vscode/
 
-#config files
-nginx*
+# local env files - real values never live in this repo
 .env*
-Dockerfile*
-Jenkinsfile*
-swarm*
-SecHeaders.conf

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# rootless nginx serving the vite spa. runtime config placeholders in
+# index.html are filled by envsubst at container start; the bundle has
+# no env-specific strings
+
+# --- BUILDER ---
+
+FROM node:24-alpine AS builder
+
+WORKDIR /src
+
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY . .
+RUN npm run build
+
+
+# --- RUNTIME ---
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine
+
+USER root
+
+RUN apk add --no-cache gettext tzdata \
+ && cp /usr/share/zoneinfo/Europe/Copenhagen /etc/localtime \
+ && echo "Europe/Copenhagen" > /etc/timezone \
+ && apk del tzdata
+
+# baked spa; entrypoint script copies it to the writable emptyDir at runtime
+COPY --chown=101:101 --from=builder /src/dist /srv/static-source
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/SecHeaders.conf /etc/nginx/SecHeaders.conf
+
+COPY docker/40-envsubst-config.sh /docker-entrypoint.d/40-envsubst-config.sh
+RUN chmod +x /docker-entrypoint.d/40-envsubst-config.sh
+
+USER 101
+
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -192,3 +192,51 @@ Ikoner skal opdateres manuelt fra designsystemets repo i src/assets/icons
 
 ## Baggrundskort
 Danmarkskortet anvender [Skærmkortet](https://dataforsyningen.dk/data/962) mens Grønlandskortet anvender [Åbent Land Grønland](https://dataforsyningen.dk/data/4771).
+
+## Container / Kubernetes
+
+CI bygger et rootless nginx-image og deployer via Helm-chartet i `charts/koordinattransformation/`. 
+
+### Runtime-config
+
+Secrets må ikke bygges ind i vores image, hvorfor `import.meta.env.VITE_*` ikke er en mulighed.
+I stedet:
+
+- `index.html` har en `window.__CONFIG__`-blok med `${VITE_*}`-placeholders.
+- Kildekoden læser via `src/runtimeConfig.js` (tynd accessor over `window.__CONFIG__`).
+- I containeren fylder `docker/40-envsubst-config.sh` placeholders ud med `envsubst` ved start.
+- I `npm run dev` gør et lille `apply: 'serve'`-plugin i `vite.config.js` det samme fra `.env.<mode>`.
+
+Vi faar et enkelt image pr. release, ingen secrets i repo/CI/image, og kan vaere sikre paa at `import.meta.env.*` altid betyder build-time, mens `window.__CONFIG__.*` altid betyder runtime.
+
+Har du brug for at tilfoeje en ny runtime-var, skal det goeres tre steder: [index.html](/index.html), [src/runtimeConfig.js](src/runtimeConfig.js), [docker/40-envsubst-config.sh](docker/40-envsubst-config.sh) (`$VARS`).
+
+### Lokalt build
+
+For at bygge lokalt med env-vars fra en .env.test:
+
+```bash
+docker build -t koordinattransformation:dev .
+docker run --rm -p 8080:8080 \
+  --env-file .env.test
+  --mount type=tmpfs,destination=/usr/share/nginx/html \
+  --mount type=tmpfs,destination=/tmp \
+  --read-only \
+  koordinattransformation:dev
+```
+
+### Release
+
+> [!NOTE]
+> Gælder pt. kun `k8s`-branchen. `main` deployes fortsat via Jenkins indtil cutover.
+
+1. Bump version, commit og tag:
+
+```bash
+npm version patch    # eller minor / major
+git push --follow-tags
+```
+
+2. CI checker at package.json matcher, og bygger + pusher det nye image og chart.
+
+3. Downstream k8s og eventuelt andre forbrugere henter den nyeste version, enten automatisk eller naar en operatoer bestemmer sig for at bumpe versionsnummeret. 

--- a/README.md
+++ b/README.md
@@ -12,38 +12,25 @@ For at udvikle og bygge projektet anbefales følgende setup
 
 ## Setup a projektet
 
-### Setup af Miljø
-For at kunne køre projektet, er der nogle miljøvariable, der skal føres ind i root directory i projeket.
+### Setup af miljø
 
-`.env.development` til development miljøet og
-`.env.production` til produktionsmiljøet.
-Et eksempel på en miljøfil er:
+Opret `.env.development` (til `npm run dev`) og `.env.test` (til Playwright)
+i root af projektet. Et eksempel:
 
 ```
-  VITE_NODE_ENV = development
-  VITE_VUE_APP_SHOW_UNPUBLISHED = true
-  VITE_NODE_OPTIONS = --openssl-legacy-provider
-  VITE_TOKEN = <token>
-  VITE_DAF_TOKEN_A = <datafordeler tjenestebruger brugernavn>
-  VITE_DAF_TOKEN_B = <datafordeler tjenestebruger password>
-  VITE_API_BASE_URL = https://api.dataforsyningen.dk/rest/webproj_test
-  VITE_API_BASE_PATH = /v1.2/trans/
+VITE_TOKEN = <token>
+VITE_DAF_TOKEN_A = <datafordeler brugernavn>
+VITE_DAF_TOKEN_B = <datafordeler password>
+VITE_API_BASE_URL = https://api.dataforsyningen.dk/rest/webproj_test
+VITE_API_BASE_PATH = /v1.2/trans/
 ```
 
-`VITE_TOKEN` er en adgangstoken, som kan oprettes på https://dataforsyningen.dk/
+`VITE_TOKEN` kan oprettes på https://dataforsyningen.dk/.
 
-`VITE_DAF_TOKEN_A` og `VITE_DAF_TOKEN_B` er hhv. brugernavn/password for en Datafordeler-tjenestebruger. 
-En tjenestebruger kan oprettes her: https://datafordeler.dk/konto/dine-tjenestebrugere/
+`VITE_DAF_TOKEN_A` / `VITE_DAF_TOKEN_B` er brugernavn/password for en
+Datafordeler-tjenestebruger (https://datafordeler.dk/konto/dine-tjenestebrugere/).
 
-Vær opmærksom på at projektet skældner mellem tre konfigurationer,
-'production', 'development' og 'test'
-
-
-***Kopier disse filer fra config repoet ind i root directory af projektet.***
-
-Disse refereres efterfølgende med `import.meta.env.[field]` <br> i sidens Store og KoorMap komponentet.
-Læs mere om Vite og miljøvariable [her](https://vitejs.dev/guide/env-and-mode.html)
-
+Læs mere om Vite-env [her](https://vitejs.dev/guide/env-and-mode.html).
 
 - Naviger til projektet i terminalen <br>
 

--- a/charts/koordinattransformation/.helmignore
+++ b/charts/koordinattransformation/.helmignore
@@ -1,0 +1,17 @@
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/koordinattransformation/Chart.yaml
+++ b/charts/koordinattransformation/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: koordinattransformation
+description: Static SPA for the Koordinattransformation site
+type: application
+
+# placeholders - the release workflow overrides both, 
+# sourcing from package.json
+version: 0.0.0
+appVersion: "0.0.0"

--- a/charts/koordinattransformation/ci/full-values.yaml
+++ b/charts/koordinattransformation/ci/full-values.yaml
@@ -1,0 +1,21 @@
+# full permutation: exercises every "on" branch - ingress (className/host/path/tls),
+# envFromSecret, imagePullSecrets
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: koordinattransformation.example.dk
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: koordinattransformation-tls
+      hosts:
+        - koordinattransformation.example.dk
+
+envFromSecret: koordinattransformation-secrets
+
+imagePullSecrets:
+  - name: ghcr-cred

--- a/charts/koordinattransformation/ci/minimal-values.yaml
+++ b/charts/koordinattransformation/ci/minimal-values.yaml
@@ -1,0 +1,8 @@
+# minimal permutation: exercises the "off" branches - pdb and topology disabled
+replicaCount: 1
+podDisruptionBudget:
+  enabled: false
+topologySpreadConstraints:
+  enabled: false
+ingress:
+  enabled: false

--- a/charts/koordinattransformation/templates/_helpers.tpl
+++ b/charts/koordinattransformation/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* fullname: release-aware name, capped at 63 chars */}}
+{{- define "koordinattransformation.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "koordinattransformation.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "koordinattransformation.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/koordinattransformation/templates/deployment.yaml
+++ b/charts/koordinattransformation/templates/deployment.yaml
@@ -22,6 +22,15 @@ spec:
       terminationGracePeriodSeconds: 30
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "koordinattransformation.selectorLabels" . | nindent 14 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/koordinattransformation/templates/deployment.yaml
+++ b/charts/koordinattransformation/templates/deployment.yaml
@@ -59,10 +59,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            # entrypoint substitutes the baked bundle into here, nginx serves from here
+            # entrypoint copies the baked bundle here, nginx serves from here
             - name: html
               mountPath: /usr/share/nginx/html
-            # nginx pid + temp paths (nginx.conf points all *_temp_path here)
+            # pid + all *_temp_path from nginx.conf
             - name: tmp
               mountPath: /tmp
       volumes:

--- a/charts/koordinattransformation/templates/deployment.yaml
+++ b/charts/koordinattransformation/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "koordinattransformation.fullname" . }}
+  labels:
+    {{- include "koordinattransformation.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "koordinattransformation.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "koordinattransformation.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 2
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- with .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # entrypoint substitutes the baked bundle into here, nginx serves from here
+            - name: html
+              mountPath: /usr/share/nginx/html
+            # nginx pid + temp paths (nginx.conf points all *_temp_path here)
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: html
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/charts/koordinattransformation/templates/ingress.yaml
+++ b/charts/koordinattransformation/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "koordinattransformation.fullname" . }}
+  labels:
+    {{- include "koordinattransformation.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "koordinattransformation.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/koordinattransformation/templates/pdb.yaml
+++ b/charts/koordinattransformation/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "koordinattransformation.fullname" . }}
+  labels:
+    {{- include "koordinattransformation.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "koordinattransformation.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/koordinattransformation/templates/service.yaml
+++ b/charts/koordinattransformation/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "koordinattransformation.fullname" . }}
+  labels:
+    {{- include "koordinattransformation.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "koordinattransformation.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/koordinattransformation/values.yaml
+++ b/charts/koordinattransformation/values.yaml
@@ -18,6 +18,13 @@ env:
 # VITE_* vars (VITE_TOKEN, VITE_DAF_TOKEN_A, VITE_DAF_TOKEN_B)
 envFromSecret: ""
 
+# spread replicas across nodes; ScheduleAnyway is soft, DoNotSchedule for strict spread
+topologySpreadConstraints:
+  enabled: true
+  maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/koordinattransformation/values.yaml
+++ b/charts/koordinattransformation/values.yaml
@@ -25,6 +25,11 @@ topologySpreadConstraints:
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 
+# keep at least one replica up during voluntary disruptions (node drains)
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/koordinattransformation/values.yaml
+++ b/charts/koordinattransformation/values.yaml
@@ -1,0 +1,56 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/klimadatastyrelsen/koordinattransformation
+  # tag defaults to .Chart.AppVersion when empty - keeps chart and image in lockstep
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# non-secret runtime config - these end up as plain env vars on the
+# container; the entrypoint envsubsts them into the bundle on start
+env:
+  VITE_API_BASE_URL: "https://api.dataforsyningen.dk/rest/webproj"
+  VITE_API_BASE_PATH: "/v1.2/trans/"
+
+# name of an externally-managed k8s Secret holding the secret-shaped
+# VITE_* vars (VITE_TOKEN, VITE_DAF_TOKEN_A, VITE_DAF_TOKEN_B)
+envFromSecret: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+# cheap static nginx, bump if observing load issues
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# uid 101 matches nginxinc/nginx-unprivileged's baked-in nginx user
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+# sane hardening defaults
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL

--- a/docker/40-envsubst-config.sh
+++ b/docker/40-envsubst-config.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# envsubst the ${VITE_*} placeholders in index.html from pod env.
+# pops into the base image's /docker-entrypoint.d/ before nginx starts.
+
+set -eu
+
+SRC=/srv/static-source
+DEST=/usr/share/nginx/html
+INDEX=index.html
+
+VARS='VITE_API_BASE_URL VITE_API_BASE_PATH VITE_TOKEN VITE_DAF_TOKEN_A VITE_DAF_TOKEN_B'
+
+missing=
+for name in $VARS; do
+  eval "val=\${$name-__UNSET__}"
+  [ "$val" = "__UNSET__" ] && missing="$missing $name"
+done
+if [ -n "$missing" ]; then
+  echo "envsubst-config: missing required env:$missing" >&2
+  exit 1
+fi
+
+# /usr/share/nginx/html is an emptyDir, fresh each start
+cp -r "$SRC"/. "$DEST"/
+
+ALLOWLIST=$(printf '${%s} ' $VARS)
+tmp=$(mktemp)
+envsubst "$ALLOWLIST" < "$DEST/$INDEX" > "$tmp"
+mv "$tmp" "$DEST/$INDEX"
+
+# catches placeholders that exist in index.html but aren't in $VARS
+leftover=$(grep -oE '\$\{VITE_[A-Z0-9_]+\}' "$DEST/$INDEX" | sort -u | tr '\n' ' ')
+if [ -n "$leftover" ]; then
+  echo "envsubst-config: unsubstituted placeholders remain: $leftover" >&2
+  exit 1
+fi

--- a/docker/SecHeaders.conf
+++ b/docker/SecHeaders.conf
@@ -1,0 +1,5 @@
+add_header Strict-Transport-Security "max-age=86400" always;
+add_header X-Frame-Options DENY always;
+add_header X-Content-Type-Options nosniff always;
+add_header Referrer-Policy "no-referrer-when-downgrade" always;
+add_header Content-Security-Policy "upgrade-insecure-requests; default-src 'self' https:; img-src 'self' data: https:; style-src 'unsafe-inline' 'self' https:; script-src 'unsafe-eval' 'unsafe-inline' 'self' https:" always;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,99 @@
+# spa config. unprivileged user, all writable paths under /tmp for
+# readOnlyRootFilesystem, listens on 8080, tls at the ingress.
+
+worker_processes 2;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+
+    # /tmp is the only writable mount
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path       /tmp/proxy;
+    fastcgi_temp_path     /tmp/fastcgi;
+    uwsgi_temp_path       /tmp/uwsgi;
+    scgi_temp_path        /tmp/scgi;
+
+    server_tokens off;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    open_file_cache max=2000 inactive=20s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        application/json
+        application/javascript
+        application/x-javascript
+        image/svg+xml;
+
+    # stdout/stderr for kubectl logs
+    access_log /dev/stdout;
+    error_log  /dev/stderr warn;
+
+    server {
+        listen 8080;
+        server_name _;
+        root /usr/share/nginx/html;
+        charset utf-8;
+
+        include SecHeaders.conf;
+
+        # k8s probe
+        location = /health {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "ok\n";
+        }
+
+        # vite content-hashes everything under /assets, safe to pin
+        location ^~ /assets/ {
+            include SecHeaders.conf;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # never cache index.html so users get new asset refs on release.
+        # internal redirects from try_files below re-enter location matching
+        # and land here, so the fallback case is covered too.
+        location = /index.html {
+            include SecHeaders.conf;
+            add_header Cache-Control "no-store" always;
+        }
+
+        location = /robots.txt {
+            include SecHeaders.conf;
+            try_files $uri =404;
+            log_not_found off;
+            access_log off;
+        }
+
+        location / {
+            include SecHeaders.conf;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,16 @@
     <link rel="stylesheet" href="./src/assets/style/KT.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Koordinattransformation</title>
+    <script>
+      // runtime config. envsubst fills these in prod; vite dev plugin in dev.
+      window.__CONFIG__ = {
+        VITE_API_BASE_URL: "${VITE_API_BASE_URL}",
+        VITE_API_BASE_PATH: "${VITE_API_BASE_PATH}",
+        VITE_TOKEN: "${VITE_TOKEN}",
+        VITE_DAF_TOKEN_A: "${VITE_DAF_TOKEN_A}",
+        VITE_DAF_TOKEN_B: "${VITE_DAF_TOKEN_B}"
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/scripts/lint-chart.sh
+++ b/scripts/lint-chart.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# lint + template + schema-validate the helm chart, locally and in ci
+# runs for the chart defaults plus every ci/*-values.yaml permutation
+set -euo pipefail   # important: without it a failure is masked by kubeconforms exit
+
+CHART_DIR="${CHART_DIR:-charts/koordinattransformation}"
+KUBE_VERSION="${KUBE_VERSION:-1.36.0}"
+CI_DIR="$CHART_DIR/ci"
+CACHE_DIR="${RUNNER_TEMP:-/tmp}/kubeconform-cache"
+
+for bin in helm kubeconform; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "::error::$bin not found in PATH"; exit 1; }
+done
+
+mkdir -p "$CACHE_DIR"
+
+run_one() {
+  local label="$1"; shift # remaining args are -f flags (may be none)
+  echo "[-] Validating: $label"
+  helm lint --strict "$CHART_DIR" "$@"
+  helm template release "$CHART_DIR" "$@" \
+    | kubeconform -strict -summary \
+        -kubernetes-version "$KUBE_VERSION" \
+        -schema-location default \
+        -cache "$CACHE_DIR" \
+        -
+}
+
+run_one "defaults" # chart defaults, no -f
+
+shopt -s nullglob # safe when ci/ is empty
+for f in "$CI_DIR"/*-values.yaml; do
+  run_one "$(basename "$f")" -f "$f"
+done
+shopt -u nullglob
+
+echo "[+] All chart validations passed!"

--- a/src/components/koortransform/inputelements/KoorInputField.vue
+++ b/src/components/koortransform/inputelements/KoorInputField.vue
@@ -359,11 +359,13 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useKtStore } from '../../../store/store.js'
 import { getGSearchCenterPoint } from '../../../helperfunctions.js'
+import { config } from '../../../runtimeConfig.js'
 
 const KtStore = useKtStore()
 const route = useRoute()
 
-const svgPath = import.meta.env.VITE_NODE_ENV === 'production' || import.meta.env.VITE_NODE_ENV === 'test' ?  KtStore.getURL + '/icons.svg#' : '/src/assets/icons/icons.svg#' 
+// PROD is any build, !PROD is the vite dev server
+const svgPath = import.meta.env.PROD ? KtStore.getURL + '/icons.svg#' : '/src/assets/icons/icons.svg#'
 const debounceTimeout = ref(null)
 
 
@@ -715,7 +717,7 @@ onMounted(async() => {
 
   const gSearch = document.querySelector('g-search')
   if (gSearch) {
-    gSearch.setAttribute('data-token', import.meta.env.VITE_TOKEN)
+    gSearch.setAttribute('data-token', config.token)
     document.querySelector('g-search').addEventListener('gsearch:select', (event) => {
       KtStore.setCoordinatesFrom({
         crs: 'EPSG:25832',

--- a/src/components/map/KoorMap.vue
+++ b/src/components/map/KoorMap.vue
@@ -40,6 +40,7 @@ import proj4 from 'proj4'
 //vue
 import { onMounted, ref, computed, watch} from 'vue'
 import { useKtStore } from '../../store/store.js'
+import { config } from '../../runtimeConfig.js'
 
 
 const KtStore = useKtStore()
@@ -61,7 +62,7 @@ const mapData = ref({
     title: 'Åbent Land',
     attributionText: 'Klimadatastyrelsen',
     attributionLink: 'https://www.klimadatastyrelsen.dk/',
-    mapURL:`https://api.dataforsyningen.dk/wms/gl_aabent_land?token=${import.meta.env.VITE_TOKEN}&service=WMS&request=GetCapabilities`,
+    mapURL:`https://api.dataforsyningen.dk/wms/gl_aabent_land?token=${config.token}&service=WMS&request=GetCapabilities`,
     source: null,
     center:   [-116987.80903933897, 7178544.1041003745],
     extent:  [-420000, 6.45e+06, 1.21e+06, 16.0382, 9.5e+06],
@@ -74,7 +75,7 @@ const mapData = ref({
     title: 'Skærmkortet',
     attributionText: 'Klimadatastyrelsen',
     attributionLink: 'https://www.klimadatastyrelsen.dk/',
-    mapURL: `https://services.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts?username=${import.meta.env.VITE_DAF_TOKEN_A}&password=${import.meta.env.VITE_DAF_TOKEN_B}&service=WMTS&request=GetCapabilities`,
+    mapURL: `https://services.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts?username=${config.dafTokenA}&password=${config.dafTokenB}&service=WMTS&request=GetCapabilities`,
     source: null,
     view: null,
     center: [587135, 6140617 + 80000],

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ app.config.compilerOptions = {
 }
 
 app.config.globalProperties.append = (path, pathToAppend) => path + (path.endsWith('/') ? '' : '/') + pathToAppend
-app.config.performance = (import.meta.env.VITE_NODE_ENV !== 'production')
+app.config.performance = !import.meta.env.PROD
 
 app.use(router)
   .use(createPinia())

--- a/src/runtimeConfig.js
+++ b/src/runtimeConfig.js
@@ -1,0 +1,12 @@
+// runtime config from window.__CONFIG__ (populated by index.html).
+// new vars: add a placeholder in index.html and a key below.
+
+const cfg = (typeof window !== 'undefined' && window.__CONFIG__) || {}
+
+export const config = {
+  apiBaseUrl: cfg.VITE_API_BASE_URL || '',
+  apiBasePath: cfg.VITE_API_BASE_PATH || '',
+  token: cfg.VITE_TOKEN || '',
+  dafTokenA: cfg.VITE_DAF_TOKEN_A || '',
+  dafTokenB: cfg.VITE_DAF_TOKEN_B || '',
+}

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { mapCoorToList } from '../helperfunctions'
+import { config } from '../runtimeConfig.js'
 /**
  * @module KtStore
  * @description
@@ -39,10 +40,10 @@ export const useKtStore = defineStore('KtStore', {
    * @property {Object} CoordinatesTo - Output coordinates after transformation.
    */
   state: () => ({
-    webproj: `${import.meta.env.VITE_API_BASE_URL || ''}${import.meta.env.VITE_API_BASE_PATH || ''}`,
-    
+    webproj: `${config.apiBaseUrl}${config.apiBasePath}`,
+
     // Authentication token, default to null if not provided
-    token: import.meta.env.VITE_TOKEN || null,
+    token: config.token || null,
 
     //baseUrl to find statically copied members
     baseUrl: new URL(import.meta.url).origin || null,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,30 +1,46 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
-export default defineConfig({
-  resolve: {
-    //forces vite to use the full vue bundler even when running in test
-    alias: {
-      'vue': 'vue/dist/vue.esm-bundler.js'
-    }
-  },
-  plugins: [
-    vue({
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) => tag.includes('ds-') || tag.includes('g-')
-        }
+// conf for dev-only substitution of ${VITE_*} placeholders in index.html,
+// grabbed from the loaded .env.<mode>
+// the same placeholders are substituted by envsubst in prod (at container startup)
+function devConfigSubst(env) {
+  return {
+    name: 'kt-dev-config-subst',
+    apply: 'serve',
+    transformIndexHtml(html) {
+      return html.replace(/\$\{(VITE_[A-Z0-9_]+)\}/g, (_, name) => env[name] ?? '')
+    },
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), 'VITE_')
+  return {
+    resolve: {
+      //forces vite to use the full vue bundler even when running in test
+      alias: {
+        'vue': 'vue/dist/vue.esm-bundler.js'
       }
-    }),
-    viteStaticCopy({
-      targets: [
-        {
-          src: './src/assets/icons/icons.svg',
-          dest: ''
+    },
+    plugins: [
+      devConfigSubst(env),
+      vue({
+        template: {
+          compilerOptions: {
+            isCustomElement: (tag) => tag.includes('ds-') || tag.includes('g-')
+          }
         }
-      ]
-    })
-  ],
-  
+      }),
+      viteStaticCopy({
+        targets: [
+          {
+            src: './src/assets/icons/icons.svg',
+            dest: ''
+          }
+        ]
+      })
+    ],
+  }
 })


### PR DESCRIPTION
Forbereder Koordinattransformation til deployment i Kubernetes. 

For at slippe afsted med et K8s-deployment i hardened infrastruktur, har jeg vaeret noedt til at lave nogle lidt mere omfattende aendringer, og til tider raekke ind i selve applikationen. Aendringer ser ud som saa:

**Build-time config -> runtime config**

Tidligere laeste applikationen environment variabler via `import.meta.env.VITE_*`, som betyder at hemmeligheder bliver foldet ind under build. Det har blandt andet betydet, at det faerdige image i sig selv er en hemmelighed, som staar i vejen for publicering til GHCR; og at vi ikke kan tilbyde environment-variabler som kubernetes `Secret`s, og derfor maatte have hemmeligheder andetsteds. 

Efter aendringen bygger vi placeholders ind, og udfylder dem i prod via [envsubst](https://man7.org/linux/man-pages/man1/envsubst.1.html). Det lader til at vaere de-facto vejen frem naar det kommer til Vite apps uden SSR. 

Den nye `src/runtimeConfig.js` goer env vars tilgaengelige, saa man fx. kan:

```js
import { config } from '../runtimeConfig.js'
const basePath = config.apiBasePath
```

**Velkommen tilbage til Docker**

Tidligere var Docker-tooling i `.gitignore`. Naar nu vores images er rene, og repoet her bliver det eneste der skal til for at drive og bygge applikationen, introducerer vi Docker igen, og tilfoejer en `Dockerfile`. Den er et multi-stage build med en rootless nginx, sat op til at fungere i en read-only kontekst med noget relativt off-the-shelf nginx opsaetning. Nyt /health endpoint, caching paa /assets (som er hased af Vite, saa fremtidige aendringer invaliderer cachen ordentligt). 

**Helm**

Meget simpelt Helm chart - der er ikke behov for det helt vilde setup her. Hardened contexts pr. default, liveness/readiness probes, umiddelbare gaestimater paa ressource-limits/requests. Hemmelige environment variabler som `Secret`s, resten som `ConfigMap`s. Koerer HA pr. default med topology spread og PDB, saa vi kan opdatere uden downtime. 

**CI/CD**

Tre workflows:

- `build.yml`: linter og bygger ved hver push/PR
- `release.yml`: udloest ved tags (semantic versioning uden v, foelger tidligere releases/tags)
- `chart.yml`: Validerer chartet, koerer kubeconform og andet gejl

Dertil en ny sektion i `README.md` omkring den nye tooling og dev env setup.. - og det var vidst det. 

Kun testet i lokalt minikube, saa der kommer muligvis lidt opfoelgende ting og sager, men det vil sandsynligvis kun beroere Chart/Docker og venner.

Koerer paa `k8s` branchen indtil vi er klar til et cutover, saa vi ikke forstyrrer almindelig drift. Sideloebende arbejde fortsaetter pa `main` - jeg skal nok staa for at merge ind i denne her loebende, hvis det bliver relevant. 