### PR TITLE
update datafordeler url

### DIFF
--- a/src/components/map/KoorMap.vue
+++ b/src/components/map/KoorMap.vue
@@ -41,17 +41,13 @@ import proj4 from 'proj4'
 import { onMounted, ref, computed, watch} from 'vue'
 import { useKtStore } from '../../store/store.js'
 
-
 const KtStore = useKtStore()
 
-//setting up projections for Skærmkortet / Åbent Land Grønland
-
+// setting up projections for Skærmkortet / Åbent Land Grønland
 epsg25832proj(proj4)
 epsg32624proj(proj4)
 epsg3184proj(proj4)
 register(proj4)
-
-
 
 const olMap = ref({})
 const overlay = ref({})
@@ -99,6 +95,7 @@ const fetchDKMap = async () => {
     matrixSet: 'View1',
   }))
 }
+
 const fetchGLMap = async () => {
   const groenlandTopoSource = await new TileWMS({
     attributions: '',
@@ -125,13 +122,13 @@ const fetchGLMap = async () => {
       }
       newUrl += queryParams.join('&')
 
-      
       imageTile.getImage().src = newUrl
     }
   })
 
   return groenlandTopoSource
 }
+
 const createView = async() => {
   return new OlView({
     center: mapData.value[coverArea.value].center,
@@ -176,8 +173,6 @@ const createMap = async() => {
     mapData.value.GL.view = mapView
   }
 
-  
-
   return new OlMap({
     target: 'map',
     controls: defaultControls({
@@ -187,30 +182,31 @@ const createMap = async() => {
     }),
     view: mapView,
     layers:
-            [
-              new TileLayer({
-                opacity: 1,
-                title: mapTitle,
-                type: 'base',
-                visible: true,
-                source: mapSource,
-              }),
-            ],
+      [
+        new TileLayer({
+          opacity: 1,
+          title: mapTitle,
+          type: 'base',
+          visible: true,
+          source: mapSource,
+        }),
+      ],
   })
 }
 
 onMounted(async() => {
   //map cannot set values in store before crs has been set elsewhere !
-  //the function yields for 70 milliseconds to allow continuation of other threads before checking again
+  //the function yields for 70 milliseconds to allow continuation of other scripts before checking again
   const waitForCRS = async() => {
     while(KtStore.CRSFrom === ''){
+      // awaiting promise resolution in event loop allows other scripts to run in this timeframe
       await new Promise(resolve => setTimeout(resolve, 70))
     }
   }
   olMap.value = await createMap()
 
   olMap.value.addControl(new ScaleLine())
-    
+
   const placedPin = document.getElementById('placed-pin')
   overlay.value = new Overlay({
     element: placedPin,
@@ -221,7 +217,7 @@ onMounted(async() => {
   olMap.value.on('click', (event) => {
     pinPointer.value = true
     const coordinate = event.coordinate
-    overlay.value.setPosition(coordinate) 
+    overlay.value.setPosition(coordinate)
     KtStore.setCoordinatesFrom_v3({
       crs: mapData.value[coverArea.value].projection,
       coordinates: {v1: event.coordinate[0], v2: event.coordinate[1], v3: null, v4: null},
@@ -229,7 +225,7 @@ onMounted(async() => {
   })
   await waitForCRS()
   const startCoor = coverArea.value === 'DK' ? [723910.4400, 6179652.8900] : mapData.value.GL.center
-  olMap.value.addOverlay(overlay.value) 
+  olMap.value.addOverlay(overlay.value)
   overlay.value.setPosition(startCoor)
   pinPointer.value = true
   KtStore.setCoordinatesFrom_v3({
@@ -245,9 +241,7 @@ watch(coorFrom, async (to, from) => {
   const crsFrom = KtStore.CRSFrom
   if(crsFrom === mapData.value[coverArea.value].projection) {
     overlay.value.setPosition(mapCoorToList(to))
-  }
-
-  else{
+  } else{
     try {
       const response = await fetch(`${KtStore.webproj}${KtStore.CRSFrom}/${mapData.value[coverArea.value].projection}/${mapCoorToList(to)}?token=${KtStore.token}`)
       if(!response.ok){

--- a/src/components/map/KoorMap.vue
+++ b/src/components/map/KoorMap.vue
@@ -143,14 +143,24 @@ const createView = async() => {
   })
 }
 
-const createMap = async() => {
+// add username and password parameters to wmts url if not present.
+const addUsernameAndPassword = (mapSource) => {
+  var userPass = `username=${import.meta.env.VITE_DAF_TOKEN_A}&password=${import.meta.env.VITE_DAF_TOKEN_B}`
+  var url = mapSource.urls[0]
+  if (!url.includes(userPass)) {
+    var new_url = url + `?${userPass}`
+    mapSource.setUrl(new_url)
+  }
+}
 
+const createMap = async() => {
   var mapSource
   var mapView
   var mapTitle
 
   if(coverArea.value === 'DK') {
     mapSource = await fetchDKMap()
+    addUsernameAndPassword(mapSource)
     mapView = await createView()
     mapTitle = mapData.value.DK.title
 

--- a/src/components/map/KoorMap.vue
+++ b/src/components/map/KoorMap.vue
@@ -74,7 +74,7 @@ const mapData = ref({
     title: 'Skærmkortet',
     attributionText: 'Klimadatastyrelsen',
     attributionLink: 'https://www.klimadatastyrelsen.dk/',
-    mapURL: `https://services.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts?username=${import.meta.env.VITE_DAF_TOKEN_A}&password=${import.meta.env.VITE_DAF_TOKEN_B}&service=WMTS&request=GetCapabilities`,
+    mapURL: `https://wmts.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts?username=${import.meta.env.VITE_DAF_TOKEN_A}&password=${import.meta.env.VITE_DAF_TOKEN_B}&service=WMTS&request=GetCapabilities`,
     source: null,
     view: null,
     center: [587135, 6140617 + 80000],

--- a/tests/e2e/basic.test.js
+++ b/tests/e2e/basic.test.js
@@ -31,8 +31,8 @@ test.describe('Map Tests', () => {
   //test for map Load(inferred from the fact that successfull communication with webmap exists)
   test('Map Connect Denmark', async({page}) => {
     await page.goto('http://localhost:4173', { waitUntil: 'domcontentloaded' })
-    const response = await page.waitForResponse( response => 
-      response.url().includes('https://services.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts') &&
+    const response = await page.waitForResponse( response =>
+      response.url().includes('https://wmts.datafordeler.dk/DKskaermkort/topo_skaermkort_daempet/1.0.0/wmts') &&
       response.status() === 200
     )
     expect(response.ok()).toBeTruthy()

--- a/tests/e2e/basic.test.js
+++ b/tests/e2e/basic.test.js
@@ -4,7 +4,7 @@ test.describe('Page Load', () => {
   test('Store Setup Denmark', async ({ page }) => {
     // Wait until the DOM content is loaded, not all resources
     await page.goto('http://localhost:4173/Denmark', { waitUntil: 'domcontentloaded' })
-    
+
     try {
       // The #c1 element only loads then the store has been set up succesfully
       await page.waitForSelector('#c1', { timeout: 5000 })
@@ -16,7 +16,7 @@ test.describe('Page Load', () => {
     // Wait until the DOM content is loaded, not all resources
     //is important to wait for domcontentloaded, as default will wait forever if one call to WMS hangs
     await page.goto('http://localhost:4173/Greenland', { waitUntil: 'domcontentloaded' })
-    
+
     try {
       // Now wait for your map element, but with a shorter timeout
       await page.waitForSelector('#c1', { timeout: 5000 })
@@ -24,7 +24,7 @@ test.describe('Page Load', () => {
       console.warn('Map did not fully load within 5 seconds. Continuing the test...')
     }
   })
-  
+
 })
 
 test.describe('Map Tests', () => {
@@ -40,13 +40,13 @@ test.describe('Map Tests', () => {
 
   test('Map Connect Greenland', async({page}) => {
     await page.goto('http://localhost:4173/Greenland', { waitUntil: 'domcontentloaded' })
-    const response = await page.waitForResponse( response => 
+    const response = await page.waitForResponse( response =>
       response.url().includes('https://api.dataforsyningen.dk/wms/gl_aabent_land') &&
       response.status() === 200
     )
     expect(response.ok()).toBeTruthy()
   })
-  
+
   test('Map Click', async ({page}) => {
     let error_msg = []
     page.on('console', msg => {
@@ -54,13 +54,13 @@ test.describe('Map Tests', () => {
         error_msg.push(msg.text())
       }
     })
-    
+
     try {
       await page.goto('http://localhost:4173', { waitUntil: 'domcontentloaded' })
       await page.waitForSelector('#map', { state: 'visible' })
 
       await page.waitForSelector('.ol-overlaycontainer', {state: 'visible'})
-      
+
       await page.waitForLoadState('networkidle')
 
       const mapElement = page.locator('#map')
@@ -69,7 +69,7 @@ test.describe('Map Tests', () => {
       const clickX = box.x + box.width / 2
       const clickY = box.y + box.height / 1.5
 
-      //Have tried to make this work for so long, but the only way is to wait... 
+      //Have tried to make this work for so long, but the only way is to wait...
       await page.waitForLoadState('load')
 
       await page.mouse.click(clickX, clickY)
@@ -111,7 +111,7 @@ test.describe('Map Tests', () => {
     await page.waitForSelector('#map', { state: 'visible' })
 
     await page.waitForSelector('.ol-overlaycontainer', {state: 'visible'})
-    
+
     await page.waitForLoadState('load')
     page.locator('#KT-crs-in-select').selectOption('WGS84 (EPSG:4326)')
     await page.waitForLoadState('networkidle')
@@ -125,7 +125,7 @@ test.describe('Map Tests', () => {
       const element = document.querySelector(selector)
       return element ? element.innerHTML.trim() : ''
     }, outputSelector)
-    
+
     expect.poll(async () => await evaluatePage(), { timeout: 3000 }).toBe('723910.4400m, 6179652.8900m, 0 m')
     const outputText = await evaluatePage()
     //allows for multiple attempts
@@ -155,7 +155,7 @@ test.describe('Map Tests', () => {
       const element = document.querySelector(selector)
       return element ? element.innerHTML.trim() : ''
     }, outputSelector)
-    
+
     // We expect the output value to be unchanged (as we only change the input CRS)
     expect.poll(async () => await changedOutputText(), {timeout: 3000}).toBe(outputText)
   })
@@ -178,12 +178,12 @@ test.describe('Map Tests', () => {
         const element = document.querySelector(selector)
         return element? element.innerHTML.trim() : ''
       }, indicator)
-        
+
       //default state when application is opened
       expect.poll(async () => await indicatorText, { timeout: 3000 } ).toBe('m')
     }
 
-  
+
     page.locator('#KT-crs-in-select').selectOption('WGS84 (EPSG:4326)')
     await page.waitForLoadState('networkidle')
 
@@ -198,7 +198,7 @@ test.describe('Map Tests', () => {
         const element = document.querySelector(selector)
         return element? element.innerHTML.trim() : ''
       }, dirIndicators.at(i))
-        
+
       //default state when application is opened
       expect(indicatorText).toBe(expectedDirIndicator.at(i))
     }
@@ -305,7 +305,7 @@ test.describe('Map Tests', () => {
       '\'',
       '\"'
     ]
-  
+
     for(let i = 0; i < measureIndicators.length; i++) {
       const evalText = await page.evaluate(selector => {
         const element = document.querySelector(selector)


### PR DESCRIPTION
The services.datafordeler.dk expires the 2026-06-30.
A replacement of wmts.datafordeler.dk lives out for the rest of the year 2026.
Although, the URLs in the XML response has username and passwords stripped. So
a little extra functionality is needed to add them back.

- **Change subdomain from services to wmts**
- **Fix missing username and password parameters**
- **Tidy up the code**
